### PR TITLE
Disable Stop button by default on Transcribe page

### DIFF
--- a/.github/pr_descriptions/feat-stop-button-disabled.md
+++ b/.github/pr_descriptions/feat-stop-button-disabled.md
@@ -1,0 +1,27 @@
+# Title
+
+Disable Stop button by default on Transcribe page
+
+## Context
+
+Users can click Stop before any recording has started, which is a no‑op and confusing. The Stop control should be disabled until a recording session begins, then re‑enabled only while recording is active.
+
+## Acceptance criteria (must be testable)
+
+- [ ] On initial page load, `#stopBtn` is disabled (`disabled` attribute true).
+- [ ] After recording starts (out of scope for this PR), Stop becomes enabled; after stopping, it is disabled again.
+
+## Out of scope
+
+- Wiring actual Start/Stop behavior or microphone permissions.
+- Styling changes beyond the disabled state.
+
+## Risks / unknowns
+
+- Some environments may rely on custom runtime logic to toggle state. Ensure the initial disabled state does not break existing flows.
+
+## Notes for Implementer
+
+- Likely minimal change in `public/index.html` (add `disabled` to `#stopBtn`) and/or initialize via script if needed.
+- Keep behavior consistent when session state initializes from storage.
+

--- a/public/index.html
+++ b/public/index.html
@@ -83,7 +83,7 @@
             <div class="field">
               <div class="control-buttons">
                 <button id="startBtn" class="button button--primary">Start</button>
-                <button id="stopBtn" class="button button--danger">Stop</button>
+                <button id="stopBtn" class="button button--danger" disabled>Stop</button>
               </div>
             </div>
 

--- a/tests/ui.stop-button-state.test.js
+++ b/tests/ui.stop-button-state.test.js
@@ -1,0 +1,34 @@
+/**
+ * UI behavior spec: Stop button default state
+ *
+ * Smallest next step: ensure the Stop button is disabled by default
+ * on the Transcribe page until recording actually starts.
+ *
+ * This test intentionally fails today to drive the change.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('Transcribe page — Stop button default state', () => {
+  test('Stop button is disabled by default on load', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'public', 'index.html'), 'utf8');
+    const dom = new JSDOM(html, {
+      url: 'http://localhost:3000/',
+      pretendToBeVisual: true,
+      resources: 'usable'
+    });
+
+    const { document } = dom.window;
+    const stopBtn = document.getElementById('stopBtn');
+
+    // Sanity check: button exists
+    expect(stopBtn).toBeTruthy();
+
+    // Spec: Stop must be disabled before any recording starts
+    // This will fail until the UI marks Stop as disabled on initial load.
+    expect(stopBtn.disabled).toBe(true);
+  });
+});
+


### PR DESCRIPTION
# Title

Disable Stop button by default on Transcribe page

## Context

Users can click Stop before any recording has started, which is a no‑op and confusing. The Stop control should be disabled until a recording session begins, then re‑enabled only while recording is active.

## Acceptance criteria (must be testable)

- [ ] On initial page load, `#stopBtn` is disabled (`disabled` attribute true).
- [ ] After recording starts (out of scope for this PR), Stop becomes enabled; after stopping, it is disabled again.

## Out of scope

- Wiring actual Start/Stop behavior or microphone permissions.
- Styling changes beyond the disabled state.

## Risks / unknowns

- Some environments may rely on custom runtime logic to toggle state. Ensure the initial disabled state does not break existing flows.

## Notes for Implementer

- Likely minimal change in `public/index.html` (add `disabled` to `#stopBtn`) and/or initialize via script if needed.
- Keep behavior consistent when session state initializes from storage.

