### PR TITLE
Tailwind v4 layout-only spec across all pages (failing tests)

### DIFF
--- a/.github/pr_descriptions/feat-tailwind-layout-spec.md
+++ b/.github/pr_descriptions/feat-tailwind-layout-spec.md
@@ -1,0 +1,51 @@
+# Title
+
+Tailwind v4 layout-only spec across all pages (failing tests)
+
+## Context
+
+We plan a full UI rebuild using Tailwind CSS v4 with container queries and modern utilities. This PR encodes the Step‑1, layout-only contract as failing tests (no production code), defining the app shell, container-query usage, and removal of inline styles on key layout elements across all pages.
+
+## Acceptance criteria (must be testable)
+
+- [ ] App shell on every page: `div.app` has `min-h-dvh grid grid-rows-[auto_1fr]` classes.
+- [ ] Main content applies `min-w-0` to prevent grid/flex overflow.
+- [ ] Each page contains at least one `@container` wrapper and uses container variants (e.g., `@sm:`, `@md:`) on child elements.
+- [ ] Viewer: `.toolbar` and all `section.card` elements have no inline `style` attributes; toolbar uses grid/flex utilities.
+- [ ] Dashboard: KPI grid `.stats` and session list sections have no inline `style` attributes and use grid/flex utilities.
+- [ ] Transcribe (index): panel headers include a `.panel-actions` container with no inline spacing; two‑pane layout is container-driven (`@container` + container variants).
+
+## Out of scope
+
+- JavaScript functionality (WebRTC, Sidekick connect/disconnect, ingestion, uploads) and behavioral changes.
+- Visual polish details and Tailwind theme token mapping (added in implementation PR).
+
+## Risks / unknowns
+
+- Browser compatibility: assumes Tailwind v4 (Safari 16.4+, Chrome 111+, Firefox 128+). If older browsers are required, we will gate features or use v3.4.
+- JS selectors may need light adjustments if markup changes. We will preserve critical `id`s and add `data-testid` where appropriate in Step‑2.
+
+## Notes for Implementer
+
+- Implement Tailwind v4 with container queries; map existing tokens to `@theme` for colors, spacing, radii, and typography.
+- Replace inline styles with utilities. Introduce small `@layer components` for primitives (btn, input, card, toolbar, panel-header/actions).
+- Ensure no horizontal overflow; add `min-w-0` on main content columns.
+- Validate reflow in narrow containers (not just viewport breakpoints).
+
+## Implementation checklist
+
+- App shell (all pages)
+  - [ ] `div.app` has `min-h-dvh grid grid-rows-[auto_1fr]`
+  - [ ] `main` has `min-w-0`
+  - [ ] At least one `@container` wrapper within main content
+- Transcribe (`public/index.html`)
+  - [ ] Two-pane layout driven by container queries (`@container` on wrapper; children use `@sm:`/`@md:` variants)
+  - [ ] `.panel-header` includes `.panel-actions` and no inline spacing
+- Viewer (`public/viewer.html`)
+  - [ ] `.toolbar` uses Tailwind utilities (no `style=`)
+  - [ ] All `section.card` elements have no `style=`; spacing via utilities
+  - [ ] At least one `@container` + child container variants present
+- Dashboard (`public/dashboard.html`)
+  - [ ] KPI grid uses Tailwind utilities (grid/flex), no `style=`
+  - [ ] Session list sections have no `style=`; layout via utilities
+

--- a/tests/ui.dashboard-layout.test.js
+++ b/tests/ui.dashboard-layout.test.js
@@ -1,0 +1,45 @@
+/**
+ * Tailwind v4 Layout Spec — Dashboard page specifics
+ *
+ * Focus: KPI grid and sessions list rely on utility classes (no inline styles)
+ * and the grid adapts responsively without inline CSS.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function load() {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'public', 'dashboard.html'), 'utf8');
+  return new JSDOM(html, { url: 'http://localhost/dashboard.html' });
+}
+
+function classes(el) {
+  return (el?.getAttribute('class') || '').toString();
+}
+
+describe('Dashboard page (dashboard.html) — layout spec', () => {
+  test('Stats (KPI) grid uses utilities; no inline style on container or cards', () => {
+    const { document } = load().window;
+    const stats = document.querySelector('.stats');
+    expect(stats).toBeTruthy();
+    expect(stats.hasAttribute('style')).toBe(false);
+    const cls = classes(stats);
+    // Expect some grid/flex utility
+    expect(/\bgrid\b|\bflex\b/.test(cls)).toBe(true);
+
+    const cards = Array.from(stats.querySelectorAll('.card'));
+    expect(cards.length).toBeGreaterThan(0);
+    const offenders = cards.filter((c) => c.hasAttribute('style'));
+    expect(offenders.length).toBe(0);
+  });
+
+  test('Sessions list container section has no inline style', () => {
+    const { document } = load().window;
+    const sections = Array.from(document.querySelectorAll('main .card'));
+    expect(sections.length).toBeGreaterThan(0);
+    const offenders = sections.filter((s) => s.hasAttribute('style'));
+    expect(offenders.length).toBe(0);
+  });
+});
+

--- a/tests/ui.index-layout.test.js
+++ b/tests/ui.index-layout.test.js
@@ -1,0 +1,52 @@
+/**
+ * Tailwind v4 Layout Spec — Transcribe page specifics
+ *
+ * Focus: two-pane layout defined via container queries and a proper
+ * panel header with a non-wrapping actions container.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function load() {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'public', 'index.html'), 'utf8');
+  return new JSDOM(html, { url: 'http://localhost/' });
+}
+
+function classes(el) {
+  return (el?.getAttribute('class') || '').toString();
+}
+
+describe('Transcribe page (index.html) — layout spec', () => {
+  test('Two-pane layout is container-driven', () => {
+    const { document } = load().window;
+    const main = document.querySelector('main');
+    expect(main).toBeTruthy();
+
+    // Spec: a wrapper inside main marks a container context
+    const hasContainer = Array.from(main.querySelectorAll('[class]')).some((el) =>
+      classes(el).includes('@container')
+    );
+    expect(hasContainer).toBe(true);
+
+    // Spec: within that container, children use container variants (e.g., @md:)
+    const hasContainerVariant = Array.from(main.querySelectorAll('[class]')).some((el) =>
+      /@sm:|@md:|@lg:/g.test(classes(el))
+    );
+    expect(hasContainerVariant).toBe(true);
+  });
+
+  test('Panel headers use a .panel-actions container (no inline spacing)', () => {
+    const { document } = load().window;
+    const headers = Array.from(document.querySelectorAll('.panel-header'));
+    expect(headers.length).toBeGreaterThan(0);
+
+    headers.forEach((header) => {
+      const actions = header.querySelector('.panel-actions');
+      expect(actions).toBeTruthy();
+      expect(actions.hasAttribute('style')).toBe(false);
+    });
+  });
+});
+

--- a/tests/ui.tailwind-layout.test.js
+++ b/tests/ui.tailwind-layout.test.js
@@ -1,0 +1,57 @@
+/**
+ * Tailwind v4 Layout Spec (App-wide)
+ *
+ * Purpose: Define Step-1 (layout-only) contract for rebuilding the UI with
+ * Tailwind v4. These tests intentionally fail against the current markup to
+ * act as the specification for the implementation PR.
+ *
+ * Scope covered here (generic across all pages):
+ * - App shell uses dynamic viewport height + grid rows [auto, 1fr]
+ * - At least one @container wrapper exists per page
+ * - Main content applies min-w-0 to avoid overflow in grid/flex cells
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function load(page) {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'public', page), 'utf8');
+  return new JSDOM(html, { url: `http://localhost/${page}` });
+}
+
+function hasClass(el, token) {
+  if (!el) return false;
+  const cls = (el.getAttribute('class') || '').toString();
+  return cls.split(/\s+/).includes(token);
+}
+
+describe('Tailwind layout spec — app shell & core invariants', () => {
+  const pages = ['index.html', 'viewer.html', 'dashboard.html'];
+
+  test.each(pages)('%s: .app uses min-h-dvh grid and grid-rows-[auto_1fr]', (page) => {
+    const { document } = load(page).window;
+    const app = document.querySelector('div.app');
+    expect(app).toBeTruthy();
+    // Spec: Tailwind classes present on the app shell container
+    expect(hasClass(app, 'min-h-dvh')).toBe(true);
+    expect(hasClass(app, 'grid')).toBe(true);
+    expect(hasClass(app, 'grid-rows-[auto_1fr]')).toBe(true);
+  });
+
+  test.each(pages)('%s: at least one @container wrapper exists', (page) => {
+    const { document } = load(page).window;
+    const anyContainer = Array.from(document.querySelectorAll('[class]')).some((el) =>
+      (el.getAttribute('class') || '').includes('@container')
+    );
+    expect(anyContainer).toBe(true);
+  });
+
+  test.each(pages)('%s: main content applies min-w-0 to prevent overflow', (page) => {
+    const { document } = load(page).window;
+    const main = document.querySelector('main');
+    expect(main).toBeTruthy();
+    expect(hasClass(main, 'min-w-0')).toBe(true);
+  });
+});
+

--- a/tests/ui.viewer-layout.test.js
+++ b/tests/ui.viewer-layout.test.js
@@ -1,0 +1,53 @@
+/**
+ * Tailwind v4 Layout Spec — Viewer page specifics
+ *
+ * Focus: toolbar and cards use utility classes (no inline styles),
+ * and the toolbar adapts with container queries.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function load() {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'public', 'viewer.html'), 'utf8');
+  return new JSDOM(html, { url: 'http://localhost/viewer.html' });
+}
+
+function classes(el) {
+  return (el?.getAttribute('class') || '').toString();
+}
+
+describe('Viewer page (viewer.html) — layout spec', () => {
+  test('Toolbar uses class-based layout (no inline style attribute)', () => {
+    const { document } = load().window;
+    const toolbar = document.querySelector('.toolbar');
+    expect(toolbar).toBeTruthy();
+    expect(toolbar.hasAttribute('style')).toBe(false);
+    // Spec: toolbar should be a grid/flex via Tailwind
+    const cls = classes(toolbar);
+    expect(/\bgrid\b|\bflex\b/.test(cls)).toBe(true);
+  });
+
+  test('Cards/sections do not rely on inline styles for padding/layout', () => {
+    const { document } = load().window;
+    const sections = Array.from(document.querySelectorAll('section.card'));
+    expect(sections.length).toBeGreaterThan(0);
+    const offenders = sections.filter((s) => s.hasAttribute('style'));
+    expect(offenders.length).toBe(0);
+  });
+
+  test('A @container wrapper exists and child uses a container variant', () => {
+    const { document } = load().window;
+    const hasContainer = Array.from(document.querySelectorAll('[class]')).some((el) =>
+      classes(el).includes('@container')
+    );
+    expect(hasContainer).toBe(true);
+
+    const hasVariant = Array.from(document.querySelectorAll('[class]')).some((el) =>
+      /@sm:|@md:|@lg:/g.test(classes(el))
+    );
+    expect(hasVariant).toBe(true);
+  });
+});
+


### PR DESCRIPTION
# Title

Tailwind v4 layout-only spec across all pages (failing tests)

## Context

We plan a full UI rebuild using Tailwind CSS v4 with container queries and modern utilities. This PR encodes the Step‑1, layout-only contract as failing tests (no production code), defining the app shell, container-query usage, and removal of inline styles on key layout elements across all pages.

## Acceptance criteria (must be testable)

- [ ] App shell on every page: `div.app` has `min-h-dvh grid grid-rows-[auto_1fr]` classes.
- [ ] Main content applies `min-w-0` to prevent grid/flex overflow.
- [ ] Each page contains at least one `@container` wrapper and uses container variants (e.g., `@sm:`, `@md:`) on child elements.
- [ ] Viewer: `.toolbar` and all `section.card` elements have no inline `style` attributes; toolbar uses grid/flex utilities.
- [ ] Dashboard: KPI grid `.stats` and session list sections have no inline `style` attributes and use grid/flex utilities.
- [ ] Transcribe (index): panel headers include a `.panel-actions` container with no inline spacing; two‑pane layout is container-driven (`@container` + container variants).

## Out of scope

- JavaScript functionality (WebRTC, Sidekick connect/disconnect, ingestion, uploads) and behavioral changes.
- Visual polish details and Tailwind theme token mapping (added in implementation PR).

## Risks / unknowns

- Browser compatibility: assumes Tailwind v4 (Safari 16.4+, Chrome 111+, Firefox 128+). If older browsers are required, we will gate features or use v3.4.
- JS selectors may need light adjustments if markup changes. We will preserve critical `id`s and add `data-testid` where appropriate in Step‑2.

## Notes for Implementer

- Implement Tailwind v4 with container queries; map existing tokens to `@theme` for colors, spacing, radii, and typography.
- Replace inline styles with utilities. Introduce small `@layer components` for primitives (btn, input, card, toolbar, panel-header/actions).
- Ensure no horizontal overflow; add `min-w-0` on main content columns.
- Validate reflow in narrow containers (not just viewport breakpoints).

## Implementation checklist

- App shell (all pages)
  - [ ] `div.app` has `min-h-dvh grid grid-rows-[auto_1fr]`
  - [ ] `main` has `min-w-0`
  - [ ] At least one `@container` wrapper within main content
- Transcribe (`public/index.html`)
  - [ ] Two-pane layout driven by container queries (`@container` on wrapper; children use `@sm:`/`@md:` variants)
  - [ ] `.panel-header` includes `.panel-actions` and no inline spacing
- Viewer (`public/viewer.html`)
  - [ ] `.toolbar` uses Tailwind utilities (no `style=`)
  - [ ] All `section.card` elements have no `style=`; spacing via utilities
  - [ ] At least one `@container` + child container variants present
- Dashboard (`public/dashboard.html`)
  - [ ] KPI grid uses Tailwind utilities (grid/flex), no `style=`
  - [ ] Session list sections have no `style=`; layout via utilities

